### PR TITLE
name change per issue 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en" dir="ltr" typeof="bibo:Document " prefix="bibo: http://purl.org/ontology/bibo/ w3p: http://www.w3.org/2001/02pd/rec54#">
 <head>
   <meta lang="" property="dc:language" content="en">
-  <title>PubSubHubbub
+  <title>PubSub
   </title>
   <meta charset="utf-8">
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-WD">
@@ -11,7 +11,7 @@
   <script class='remove'>
   var respecConfig = {
     specStatus: "ED",
-    shortName: "pubsubhubbub",
+    shortName: "pubsub",
     editors: [{
       name: "Julien Genestoux",
       url: "https://www.ouvre-boite.com/",
@@ -29,7 +29,7 @@
     }, {
       name: "Martin Atkins"
     }],
-    edDraftURI: "https://w3c.github.io/pubsubhubbub",
+    edDraftURI: "https://w3c.github.io/pubsub/",
     wg: "Social Web Working Group",
     wgURI: "https://www.w3.org/Social/WG",
     wgPublicList: "public-socialweb",
@@ -39,15 +39,15 @@
       data: [
         {
           value: 'Github',
-          href: 'https://github.com/w3c/pubsubhubbub'
+          href: 'https://github.com/w3c/pubsub'
         },
         {
           value: 'Issues',
-          href: 'https://github.com/w3c/pubsubhubbub/issues'
+          href: 'https://github.com/w3c/pubsub/issues'
         },
         {
           value: 'Commits',
-          href: 'https://github.com/w3c/pubsubhubbub/commits/master'
+          href: 'https://github.com/w3c/pubsub/commits/master'
         }
       ]
     }],
@@ -85,7 +85,7 @@
 
   <section id="sotd">
     <p>
-      This document is currently an editor's draft. Current bugs and issues are managed in <a href="https://github.com/w3c/pubsubhubbub/issues">GitHub</a>.
+      This document is currently an editor's draft. Current bugs and issues are managed in <a href="https://github.com/w3c/pubsub/issues">GitHub</a>.
     </p>
   </section>
 
@@ -123,7 +123,7 @@
 
   <section id="discovery">
     <h2>Discovery</h2>
-    <p>A potential subscriber initiates discovery by retrieving (GET or HEAD request) the topic to which it wants to subscribe. The HTTP [[RFC7231]] response from the publisher MUST include at least one Link Header [[!RFC5988]] with <samp>rel=hub</samp> (a hub link header) as well as exactly one Link Header [[!RFC5988]] with <samp>rel=self</samp> (the self link header). The former MUST indicate the exact URL of a PubSubHubbub hub designated by the publisher. If more than one URL is specified, it is expected that the publisher pings each of these URLs, so the subscriber may subscribe to one or more of these. The latter will point to the permanent URL for the resource being polled.</p>
+    <p>A potential subscriber initiates discovery by retrieving (GET or HEAD request) the topic to which it wants to subscribe. The HTTP [[RFC7231]] response from the publisher MUST include at least one Link Header [[!RFC5988]] with <samp>rel=hub</samp> (a hub link header) as well as exactly one Link Header [[!RFC5988]] with <samp>rel=self</samp> (the self link header). The former MUST indicate the exact URL of a PubSub hub designated by the publisher. If more than one URL is specified, it is expected that the publisher pings each of these URLs, so the subscriber may subscribe to one or more of these. The latter will point to the permanent URL for the resource being polled.</p>
     <p>In the absence of HTTP [[!RFC7231]] Link headers, subscribers MAY fall back to other methods to discover the hub(s) and the canonical URI of the topic. If the topic is an XML based feed, it MAY use embedded link elements as described in Appendix B of Web Linking [[!RFC5988]]. Similarly, for HTML pages, it MAY use embedded link elements as described in Appendix A of Web Linking [[!RFC5988]]. Finally, publishers MAY also use the Well-Known Uniform Resource Identifiers [[!RFC5785]] .host-meta to include the &lt;Link&gt; element with rel="hub".</p>
   </section>
 


### PR DESCRIPTION
Updated github links for "pubsub", and any prose references from PubSubHubbub to PubSub.